### PR TITLE
Fix getting wrong tab when opening more than one window

### DIFF
--- a/src/cookiecutter.js
+++ b/src/cookiecutter.js
@@ -4,7 +4,7 @@ function init() {
 }
 
 function copyCurrentTabCookie() {
-	chrome.tabs.query({active: true}, function(tabs) {
+	chrome.tabs.query({active: true, lastFocusedWindow: true}, function(tabs) {
 		if (!tabs.length) {
 			showError("Couldn't get the current active tab.")
 			return;

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Cookie Cutter",
-  "version": "1.1",
+  "version": "1.2",
   "description": "Allows you to easily copy your cookie from any website to the clipboard.",
   "browser_action": {
     "default_popup": "index.html"


### PR DESCRIPTION
Fix issue: 
When opening more than one window, the extension may get wrong tab. 